### PR TITLE
Reusing read buffer for readPackets

### DIFF
--- a/transports/obfs4/obfs4.go
+++ b/transports/obfs4/obfs4.go
@@ -265,7 +265,7 @@ func (sf *obfs4ServerFactory) WrapConn(conn net.Conn) (net.Conn, error) {
 		iatDist = probdist.New(sf.iatSeed, 0, maxIATDelay, biasedDist)
 	}
 
-	c := &obfs4Conn{conn, true, lenDist, iatDist, sf.iatMode, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil, nil}
+	c := &obfs4Conn{conn, true, lenDist, iatDist, sf.iatMode, bytes.NewBuffer(nil), bytes.NewBuffer(nil), make([]byte, consumeReadSize), nil, nil}
 
 	startTime := time.Now()
 
@@ -288,6 +288,7 @@ type obfs4Conn struct {
 
 	receiveBuffer        *bytes.Buffer
 	receiveDecodedBuffer *bytes.Buffer
+	readBuffer           []byte
 
 	encoder *framing.Encoder
 	decoder *framing.Decoder
@@ -311,7 +312,7 @@ func newObfs4ClientConn(conn net.Conn, args *obfs4ClientArgs) (c *obfs4Conn, err
 	}
 
 	// Allocate the client structure.
-	c = &obfs4Conn{conn, false, lenDist, iatDist, args.iatMode, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil, nil}
+	c = &obfs4Conn{conn, false, lenDist, iatDist, args.iatMode, bytes.NewBuffer(nil), bytes.NewBuffer(nil), make([]byte, consumeReadSize), nil, nil}
 
 	// Start the handshake timeout.
 	deadline := time.Now().Add(clientHandshakeTimeout)

--- a/transports/obfs4/packet.go
+++ b/transports/obfs4/packet.go
@@ -110,9 +110,8 @@ func (conn *obfs4Conn) makePacket(w io.Writer, pktType uint8, data []byte, padLe
 
 func (conn *obfs4Conn) readPackets() (err error) {
 	// Attempt to read off the network.
-	var buf [consumeReadSize]byte
-	rdLen, rdErr := conn.Conn.Read(buf[:])
-	conn.receiveBuffer.Write(buf[:rdLen])
+	rdLen, rdErr := conn.Conn.Read(conn.readBuffer)
+	conn.receiveBuffer.Write(conn.readBuffer[:rdLen])
 
 	var decoded [framing.MaximumFramePayloadLength]byte
 	for conn.receiveBuffer.Len() > 0 {


### PR DESCRIPTION
Fixes getlantern/lantern#5365

There's no need to reallocate a buffer on every call to `readPackets()`. In Lantern, this allocation alone was accounting for around 70% of all allocations by the program.