### PR TITLE
port to a Go module

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,14 @@ handshake variants without being obscenely slow is non-trivial.
 
 ### Dependencies
 
-Build time library dependencies are handled by go get automatically but are
-listed for clarity.
+Build time library dependencies are handled by the Go module automatically, but
+are listed for clarity.
 
- * Go 1.2.0 or later.   Prior versions of Go (Eg: 1.0.2) are missing certain
+If you are on Go versions earlier than 1.11, you might need to run `go get -d
+./...` to download all the dependencies. Note however, that modules always use
+the same dependency versions, while `go get -d` always downloads master.
+
+ * Go 1.2.0 or later. Prior versions of Go (Eg: 1.0.2) are missing certain
    important parts of the runtime library like a SHA256 implementation.
  * go.crypto (https://golang.org/x/crypto)
  * go.net (https://golang.org/x/net)
@@ -43,10 +47,10 @@ listed for clarity.
 ### Installation
 
 To build:
-`go get git.torproject.org/pluggable-transports/obfs4.git/obfs4proxy`
 
-To install:
-Copy `$GOPATH/bin/obfs4proxy` to a permanent location (Eg: `/usr/local/bin`)
+	go build ./obfs4proxy
+
+To install, copy `obfsproxy` to a permanent location (Eg: `/usr/local/bin`)
 
 Client side torrc configuration:
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module git.torproject.org/pluggable-transports/obfs4.git
+
+require (
+	git.torproject.org/pluggable-transports/goptlib.git v0.0.0-20180321061416-7d56ec4f381e
+	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412
+	github.com/dchest/siphash v1.2.0
+	golang.org/x/crypto v0.0.0-20181015023909-0c41d7ab0a0e
+	golang.org/x/net v0.0.0-20181011144130-49bb7cea24b1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+git.torproject.org/pluggable-transports/goptlib.git v0.0.0-20180321061416-7d56ec4f381e h1:PYcONLFUhr00kGrq7Mf14JRtoXHG7BOSKIfIha0Hu5Q=
+git.torproject.org/pluggable-transports/goptlib.git v0.0.0-20180321061416-7d56ec4f381e/go.mod h1:YT4XMSkuEXbtqlydr9+OxqFAyspUv0Gr9qhM3B++o/Q=
+github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
+github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
+github.com/dchest/siphash v1.2.0 h1:YWOShuhvg0GqbQpMa60QlCGtEyf7O7HC1Jf0VjdQ60M=
+github.com/dchest/siphash v1.2.0/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBlVnOnt4=
+golang.org/x/crypto v0.0.0-20181015023909-0c41d7ab0a0e h1:IzypfodbhbnViNUO/MEh0FzCUooG97cIGfdggUrUSyU=
+golang.org/x/crypto v0.0.0-20181015023909-0c41d7ab0a0e/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/net v0.0.0-20181011144130-49bb7cea24b1 h1:Y/KGZSOdz/2r0WJ9Mkmz6NJBusp0kiNx1Cn82lzJQ6w=
+golang.org/x/net v0.0.0-20181011144130-49bb7cea24b1/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
The biggest win is that we now declare what versions of each dependency
we require to build. This way, building a certain version of obfs4 will
always use the same source code, independent of the master branch of
each dependency.

This is necessary for reproducible builds. On top of that, go.sum
contains checksums of all the transitive dependencies and their modules,
so the build system will also recognise when the source code has been
changed.

Updated the build instructions accordingly. We don't drop support for
earlier Go versions, but those won't get the benefit of reproducible
builds unless we start vendoring the dependencies too.