### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To build:
 
 	`go build -o obfs4proxy/obfs4proxy ./obfs4proxy`
 
-To install, copy `./obfs4proxy/obfsproxy` to a permanent location
+To install, copy `./obfs4proxy/obfs4proxy` to a permanent location
 (Eg: `/usr/local/bin`)
 
 Client side torrc configuration:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ the same dependency versions, while `go get -d` always downloads master.
 
 To build:
 
-	`go build -o obfs4proxy/obfs4proxy ./obfs4proxy`
+```
+go build -o obfs4proxy/obfs4proxy ./obfs4proxy
+```
 
 To install, copy `./obfs4proxy/obfs4proxy` to a permanent location
 (Eg: `/usr/local/bin`)


### PR DESCRIPTION
You have a typo.
After the assembly, the binary file `obfs4proxy` is created, in the scooping line you say you must copy `obfsproxy`. 