### PR TITLE
Fix README.md markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ the same dependency versions, while `go get -d` always downloads master.
 
 To build:
 
-	`go build -o obfs4proxy/obfs4proxy ./obfs4proxy`
+```bash
+go build -o obfs4proxy/obfs4proxy ./obfs4proxy
+```
 
 To install, copy `./obfs4proxy/obfsproxy` to a permanent location
 (Eg: `/usr/local/bin`)


### PR DESCRIPTION
Should remove the extra ` char in the beginning and ending of the line.
![image](https://github.com/user-attachments/assets/3ae56775-50b4-43ac-a6ee-6b0b6bc45cb9)
